### PR TITLE
Add user validation middleware with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,18 @@
   "description": "",
   "main": "src/main.js",
   "scripts": {
-    "start": "node src/main.js"
+    "start": "node src/main.js",
+    "test": "mocha"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "supertest": "^6.3.3",
+    "nock": "^13.3.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,50 @@ const port = 3000
 // Parse incoming JSON bodies
 app.use(express.json())
 
+// Validate payload for POST /users
+function validateUser (req, res, next) {
+  const user = req.body
+  if (typeof user !== 'object' || user === null) {
+    return res.status(400).json({ error: 'Invalid user data' })
+  }
+
+  const { id, name, username, email, address, phone, website, company } = user
+
+  if (typeof id !== 'number' ||
+      typeof name !== 'string' ||
+      typeof username !== 'string' ||
+      typeof email !== 'string' ||
+      typeof phone !== 'string' ||
+      typeof website !== 'string' ||
+      typeof address !== 'object' || address === null ||
+      typeof company !== 'object' || company === null) {
+    return res.status(400).json({ error: 'Invalid user data' })
+  }
+
+  const { street, suite, city, zipcode, geo } = address
+  if (typeof street !== 'string' ||
+      typeof suite !== 'string' ||
+      typeof city !== 'string' ||
+      typeof zipcode !== 'string' ||
+      typeof geo !== 'object' || geo === null) {
+    return res.status(400).json({ error: 'Invalid user data' })
+  }
+
+  const { lat, lng } = geo
+  if (typeof lat !== 'string' || typeof lng !== 'string') {
+    return res.status(400).json({ error: 'Invalid user data' })
+  }
+
+  const { name: companyName, catchPhrase, bs } = company
+  if (typeof companyName !== 'string' ||
+      typeof catchPhrase !== 'string' ||
+      typeof bs !== 'string') {
+    return res.status(400).json({ error: 'Invalid user data' })
+  }
+
+  next()
+}
+
 // Base URL for the remote microservice
 const BASE_URL = 'https://jsonplaceholder.typicode.com'
 
@@ -42,7 +86,7 @@ app.get('/users/:userId', async (req, res) => {
 })
 
 // Create a new user
-app.post('/users', async (req, res) => {
+app.post('/users', validateUser, async (req, res) => {
   try {
     const response = await fetch(`${BASE_URL}/users`, {
       method: 'POST',
@@ -73,6 +117,10 @@ app.delete('/users/:userId', async (req, res) => {
   }
 })
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
-})
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Example app listening on port ${port}`)
+  })
+}
+
+module.exports = app

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest')
+const nock = require('nock')
+const app = require('../src/main')
+
+const BASE_URL = 'https://jsonplaceholder.typicode.com'
+
+describe('POST /users validation', () => {
+  it('returns 400 when payload is invalid', async () => {
+    const res = await request(app).post('/users').send({})
+    if (res.status !== 400) throw new Error(`Expected 400, got ${res.status}`)
+  })
+
+  it('returns 201 when payload is valid', async () => {
+    const validUser = {
+      id: 1,
+      name: 'Leanne Graham',
+      username: 'Bret',
+      email: 'Sincere@april.biz',
+      address: {
+        street: 'Kulas Light',
+        suite: 'Apt. 556',
+        city: 'Gwenborough',
+        zipcode: '92998-3874',
+        geo: {
+          lat: '-37.3159',
+          lng: '81.1496'
+        }
+      },
+      phone: '1-770-736-8031 x56442',
+      website: 'hildegard.org',
+      company: {
+        name: 'Romaguera-Crona',
+        catchPhrase: 'Multi-layered client-server neural-net',
+        bs: 'harness real-time e-markets'
+      }
+    }
+
+    // Mock the remote service
+    nock(BASE_URL)
+      .post('/users', body => true)
+      .reply(201, validUser)
+
+    const res = await request(app).post('/users').send(validUser)
+    if (res.status !== 201) throw new Error(`Expected 201, got ${res.status}`)
+  })
+})


### PR DESCRIPTION
## Summary
- add validation middleware for POST /users
- export app and only listen when main
- add unit tests for user creation validation
- add dev dependencies and test script

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm test` *(fails: mocha not found)*